### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     restart: always
     depends_on:
       - openbas
-collector-atomic-red-team:
+  collector-atomic-red-team:
     image: openbas/collector-atomic-red-team:1.1.1
     environment:
       - OPENBAS_URL=http://openbas:8080


### PR DESCRIPTION
Missing two spaces in front of collector-atomic-red-team resulting in errors in Portainer editor.