### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
     restart: always
     depends_on:
       - openbas
-collector-atomic-red-team:
+  collector-atomic-red-team:
     image: openbas/collector-atomic-red-team:1.2.0
     environment:
       - OPENBAS_URL=http://openbas:8080
@@ -106,7 +106,7 @@ collector-atomic-red-team:
       - COLLECTOR_LOG_LEVEL=info
     restart: always
     depends_on:
-      - openbas      
+      - openbas
 volumes:
   pgsqldata:
   s3data:


### PR DESCRIPTION
Fix an error in the identation of the `collector-atomic-red-team` service.

```
validating /tmp/openbas-docker/docker-compose.yml: (root) Additional property collector-atomic-red-team is not allowed
```

It was caused by a pair of missing spaces.