### PR TITLE
[docker] StarterPack - Fix CVE by NVD NIST name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
       - OPENBAS_TOKEN=${OPENBAS_ADMIN_TOKEN}
       - COLLECTOR_ID=${COLLECTOR_NVD_NIST_CVE_ID} # Valid UUIDv4
       - NVD_NIST_CVE_API_KEY=${COLLECTOR_NVD_NIST_CVE_API_KEY}
-      - "COLLECTOR_NAME=Cve by NVD NIST"
+      - "COLLECTOR_NAME=CVE by NVD NIST"
       - COLLECTOR_LOG_LEVEL=info
     depends_on:
       openbas:


### PR DESCRIPTION
* Context
For the StarterPack process, we need to implement by default one new collector (CVE by NVD NIST) and two new injectors (NMAP and Nuclei).

* Proposed changes

Fix collector NVD Nist CVE name

* Related issues
Closes https://github.com/OpenAEV-Platform/openaev/issues/3527