### PR TITLE
chore(db): update postgres data mount path for version 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: openaev
     volumes:
-      - pgsqldata:/var/lib/postgresql/data
+      - pgsqldata:/var/lib/postgresql/18/docker
     restart: always
     healthcheck:
       test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "openaev" ]


### PR DESCRIPTION
### This PR updates the PostgreSQL data mounting path to align with the new standards introduced in the PostgreSQL 18 official Docker images.

<img width="1311" height="567" alt="image" src="https://github.com/user-attachments/assets/492db700-77cf-42cb-8f03-c074d307dd61" />
