### PR TITLE
fix: rollback previous version of postgres

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   openaev-dev-pgsql:
     container_name: openaev-dev-pgsql
-    image: postgres:18-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 3
     restart: always
   pgsql:
-    image: postgres:18-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
Context
For Postgres V18, a dump/restore using pg_dumpall or use of pg_upgrade or logical replication is required for those wishing to migrate data from any previous release. [Release notes](https://www.postgresql.org/docs/release/18.0/)

Issue linked
On openaev repository https://github.com/OpenAEV-Platform/docker/issues/123

After some investigation, it appears that this resulted in breaking changes and without providing a clear migration path for our users.
We will work on resolving this and, in the meantime, revert to V17.

Here is a detailed [documentation ](https://aronschueler.de/blog/2025/10/30/fixing-postgres-18-docker-compose-startup/)explaining the ins and outs.
