### PR TITLE
[docker] Bundle XTM One in the default stack

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,8 +33,8 @@ IMAP_STARTTLS_ENABLE=false
 XTM_COMPOSER_ID=8215614c-7139-422e-b825-b20fd2a13a23
 COMPOSE_PROJECT_NAME=xtm
 
-# Shared secret used by OpenAEV to register itself with XTM One.
-# The platforms sharing an XTM One instance MUST use the same value.
+# Shared secret used to register the platforms with XTM One.
+# All platforms sharing an XTM One instance MUST use the same value.
 PLATFORM_REGISTRATION_TOKEN=ChangeMeWithGeneratedRandomString # [MANDATORY] Replace with a long random string (e.g. `openssl rand -hex 32`)
 
 ###########################
@@ -44,8 +44,8 @@ PLATFORM_REGISTRATION_TOKEN=ChangeMeWithGeneratedRandomString # [MANDATORY] Repl
 OPENAEV_HOST=localhost
 OPENAEV_PORT=8080
 OPENAEV_EXTERNAL_SCHEME=http
-OPENAEV_ADMIN_EMAIL= # ChangeMe@domain.com
-OPENAEV_ADMIN_PASSWORD= # ChangeMe
+OPENAEV_ADMIN_EMAIL=admin@filigran.io
+OPENAEV_ADMIN_PASSWORD=changeme
 OPENAEV_ADMIN_TOKEN=00000000-0000-0000-0000-000000000000 # [MANDATORY] Replace with a valid UUIDv4
 OPENAEV_HEALTHCHECK_KEY=ChangeMe
 OPENAEV_ADMIN_ENCRYPTION_KEY= # ChangeMe
@@ -79,14 +79,13 @@ XTM_ONE_PORT=8090
 XTM_ONE_EXTERNAL_SCHEME=http
 # Image tag for xtmone/platform and xtmone/worker (e.g. rolling, testing-xtm-one, 1.260513.0)
 XTM_ONE_VERSION=rolling
-# Must match OPENAEV_ADMIN_EMAIL so XTM One's JWT email claim resolves to an
-# existing user on the platform.
-XTM_ONE_ADMIN_EMAIL=admin@openaev.io
+# Must match the admin email of the connected platform(s) so XTM One's JWT
+# email claim resolves to an existing user.
+XTM_ONE_ADMIN_EMAIL=admin@filigran.io
 XTM_ONE_ADMIN_PASSWORD=changeme
 # Long random string (e.g. `openssl rand -hex 32`). Used to sign sessions/tokens.
 XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString
-# Credentials for the dedicated pgsql-xtm-one Postgres instance (kept
-# separate from the OpenAEV pg cluster).
+# Credentials for the dedicated pgsql-xtm-one Postgres instance.
 XTM_ONE_POSTGRES_USER=xtmone
 XTM_ONE_POSTGRES_PASSWORD=ChangeMe
 # Optional: bucket name in MinIO (auto-created on first boot)

--- a/.env.sample
+++ b/.env.sample
@@ -77,8 +77,6 @@ INJECTOR_NUCLEI_ID=e1bad898-9804-427d-99e4-dc32c5f2898d
 XTM_ONE_HOST=localhost
 XTM_ONE_PORT=8090
 XTM_ONE_EXTERNAL_SCHEME=http
-# Image tag for xtmone/platform and xtmone/worker (e.g. rolling, testing-xtm-one, 1.260513.0)
-XTM_ONE_VERSION=rolling
 # Must match the admin email of the connected platform(s) so XTM One's JWT
 # email claim resolves to an existing user.
 XTM_ONE_ADMIN_EMAIL=admin@filigran.io

--- a/.env.sample
+++ b/.env.sample
@@ -33,6 +33,10 @@ IMAP_STARTTLS_ENABLE=false
 XTM_COMPOSER_ID=8215614c-7139-422e-b825-b20fd2a13a23
 COMPOSE_PROJECT_NAME=xtm
 
+# Shared secret used by OpenAEV to register itself with XTM One.
+# The platforms sharing an XTM One instance MUST use the same value.
+PLATFORM_REGISTRATION_TOKEN=ChangeMeWithGeneratedRandomString # [MANDATORY] Replace with a long random string (e.g. `openssl rand -hex 32`)
+
 ###########################
 # OPENAEV                 #
 ###########################
@@ -65,3 +69,29 @@ COLLECTOR_NVD_NIST_CVE_API_KEY= #Optionnal but recommended
 
 INJECTOR_NMAP_ID=76f8f4d6-9f6f-4e61-befc-48f735876a4a
 INJECTOR_NUCLEI_ID=e1bad898-9804-427d-99e4-dc32c5f2898d
+
+###########################
+# XTM ONE                 #
+###########################
+
+XTM_ONE_HOST=localhost
+XTM_ONE_PORT=8090
+XTM_ONE_EXTERNAL_SCHEME=http
+# Image tag for filigran/xtm-one and filigran/xtm-one-worker (e.g. rolling, testing-xtm-one, 1.260513.0)
+XTM_ONE_VERSION=rolling
+# Must match OPENAEV_ADMIN_EMAIL so XTM One's JWT email claim resolves to an
+# existing user on the platform.
+XTM_ONE_ADMIN_EMAIL=admin@openaev.io
+XTM_ONE_ADMIN_PASSWORD=changeme
+# Long random string (e.g. `openssl rand -hex 32`). Used to sign sessions/tokens.
+XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString
+# Credentials for the dedicated pgsql-xtm-one Postgres instance (kept
+# separate from the OpenAEV pg cluster).
+XTM_ONE_POSTGRES_USER=xtmone
+XTM_ONE_POSTGRES_PASSWORD=ChangeMe
+# Optional: bucket name in MinIO (auto-created on first boot)
+XTM_ONE_S3_BUCKET=xtm-one-files
+# Optional: enterprise license PEM (leave empty in xtm_one mode)
+XTM_ONE_ENTERPRISE_LICENSE=
+XTM_ONE_LOG_LEVEL=info
+XTM_ONE_LOG_FORMAT=json

--- a/.env.sample
+++ b/.env.sample
@@ -77,7 +77,7 @@ INJECTOR_NUCLEI_ID=e1bad898-9804-427d-99e4-dc32c5f2898d
 XTM_ONE_HOST=localhost
 XTM_ONE_PORT=8090
 XTM_ONE_EXTERNAL_SCHEME=http
-# Image tag for filigran/xtm-one and filigran/xtm-one-worker (e.g. rolling, testing-xtm-one, 1.260513.0)
+# Image tag for xtmone/platform and xtmone/worker (e.g. rolling, testing-xtm-one, 1.260513.0)
 XTM_ONE_VERSION=rolling
 # Must match OPENAEV_ADMIN_EMAIL so XTM One's JWT email claim resolves to an
 # existing user on the platform.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,17 @@ services:
       timeout: 5s
       retries: 3
     restart: always
+  redis:
+    # Used by XTM One.
+    image: redis:8.6.3
+    restart: always
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
   pgsql:
     image: postgres:17-alpine
     environment:
@@ -166,6 +177,9 @@ services:
       - OPENAEV_MAIL_IMAP_SSL_TRUST=*
       - OPENAEV_MAIL_IMAP_STARTTLS_ENABLE=${IMAP_STARTTLS_ENABLE}
       - OPENAEV_WITH-PROXY=${OPENAEV_WITH_PROXY}
+      # XTM One
+      - OPENAEV_XTM_ONE_URL=http://xtm-one:4000
+      - OPENAEV_XTM_ONE_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
     ports:
       - "${OPENAEV_PORT}:8080"
     depends_on:
@@ -266,9 +280,95 @@ services:
       openaev:
         condition: service_healthy
     restart: always
+
+  ###########################
+  # XTM ONE                 #
+  ###########################
+
+  pgsql-xtm-one:
+    # Dedicated pgvector-enabled instance for XTM One (kept separate from
+    # the OpenAEV pg cluster to isolate data and migrations).
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
+      POSTGRES_DB: xtm_one
+    volumes:
+      - pgsqlxtmonedata:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "xtm_one" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  xtm-one:
+    image: filigran/xtm-one:${XTM_ONE_VERSION:-rolling}
+    environment:
+      - PLATFORM_MODE=xtm_one
+      - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
+      - BASE_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      - FRONTEND_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}
+      - SECRET_KEY=${XTM_ONE_SECRET_KEY}
+      - DATABASE_URL=postgresql+asyncpg://${XTM_ONE_POSTGRES_USER}:${XTM_ONE_POSTGRES_PASSWORD}@pgsql-xtm-one:5432/xtm_one
+      - REDIS_URL=redis://redis:6379
+      - S3_ENDPOINT=minio:9000
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - S3_BUCKET=${XTM_ONE_S3_BUCKET:-xtm-one-files}
+      - S3_USE_SSL=false
+      - LOG_LEVEL=${XTM_ONE_LOG_LEVEL:-info}
+      - LOG_FORMAT=${XTM_ONE_LOG_FORMAT:-json}
+      - ENTERPRISE_LICENSE=${XTM_ONE_ENTERPRISE_LICENSE:-}
+      # Internal API endpoint for the OpenAEV integration (Docker hostname)
+      - OPENAEV_API_URL=http://openaev:8080
+    ports:
+      - "${XTM_ONE_PORT}:4000"
+    depends_on:
+      pgsql-xtm-one:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/api/health')\""]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  xtm-one-worker:
+    image: filigran/xtm-one-worker:${XTM_ONE_VERSION:-rolling}
+    environment:
+      - PLATFORM_MODE=xtm_one
+      - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
+      - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}
+      - SECRET_KEY=${XTM_ONE_SECRET_KEY}
+      - DATABASE_URL=postgresql+asyncpg://${XTM_ONE_POSTGRES_USER}:${XTM_ONE_POSTGRES_PASSWORD}@pgsql-xtm-one:5432/xtm_one
+      - REDIS_URL=redis://redis:6379
+      - S3_ENDPOINT=minio:9000
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - S3_BUCKET=${XTM_ONE_S3_BUCKET:-xtm-one-files}
+      - S3_USE_SSL=false
+      - LOG_LEVEL=${XTM_ONE_LOG_LEVEL:-info}
+      - LOG_FORMAT=${XTM_ONE_LOG_FORMAT:-json}
+      - ENTERPRISE_LICENSE=${XTM_ONE_ENTERPRISE_LICENSE:-}
+    depends_on:
+      xtm-one:
+        condition: service_healthy
+    restart: always
+
 volumes:
   pgsqldata:
   s3data:
   amqpdata:
   esdata:
   rsakeys:
+  redisdata:
+  pgsqlxtmonedata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,7 +334,7 @@ services:
         condition: service_healthy
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/api/health')\""]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:4000/api/health || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,7 +302,7 @@ services:
       retries: 5
 
   xtm-one:
-    image: xtmone/platform:${XTM_ONE_VERSION:-rolling}
+    image: xtmone/platform:latest
     environment:
       - PLATFORM_MODE=xtm_one
       - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
@@ -341,7 +341,7 @@ services:
       start_period: 60s
 
   xtm-one-worker:
-    image: xtmone/worker:${XTM_ONE_VERSION:-rolling}
+    image: xtmone/worker:latest
     environment:
       - PLATFORM_MODE=xtm_one
       - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,7 +303,7 @@ services:
       retries: 5
 
   xtm-one:
-    image: filigran/xtm-one:${XTM_ONE_VERSION:-rolling}
+    image: xtmone/platform:${XTM_ONE_VERSION:-rolling}
     environment:
       - PLATFORM_MODE=xtm_one
       - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
@@ -342,7 +342,7 @@ services:
       start_period: 60s
 
   xtm-one-worker:
-    image: filigran/xtm-one-worker:${XTM_ONE_VERSION:-rolling}
+    image: xtmone/worker:${XTM_ONE_VERSION:-rolling}
     environment:
       - PLATFORM_MODE=xtm_one
       - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -286,8 +286,7 @@ services:
   ###########################
 
   pgsql-xtm-one:
-    # Dedicated pgvector-enabled instance for XTM One (kept separate from
-    # the OpenAEV pg cluster to isolate data and migrations).
+    # Dedicated pgvector-enabled instance for XTM One.
     image: pgvector/pgvector:pg17
     environment:
       POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}


### PR DESCRIPTION
### Proposed changes

Adds XTM One alongside OpenAEV in the default compose stack so `docker compose up -d` brings up the AI assistant next to the platform.

- New `redis` service (required by XTM One) and a dedicated `pgsql-xtm-one` service (`pgvector/pgvector:pg17`) with its own credentials and volume, isolated from the OpenAEV pg cluster.
- New `xtm-one` and `xtm-one-worker` services pulled from the published `xtmone/platform:latest` and `xtmone/worker:latest` images ([hub.docker.com/u/xtmone](https://hub.docker.com/u/xtmone)), reusing the existing `minio`. Images are pinned to `:latest` like `openaev/platform`.
- `xtm-one` is exposed on host port `8090`; `BASE_URL` and `FRONTEND_URL` both resolve to the templated `${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}` (no hard-coded internal hostnames). Its healthcheck uses `curl` (present in the image; `wget` is not).
- OpenAEV is wired to XTM One via `OPENAEV_XTM_ONE_URL` / `OPENAEV_XTM_ONE_TOKEN` and the shared `PLATFORM_REGISTRATION_TOKEN`.
- `.env.sample` documents the new `XTM ONE` block and the mandatory-to-rotate `PLATFORM_REGISTRATION_TOKEN`. Admin email defaults to `admin@filigran.io`.

This mirrors the unified `xtm-docker` stack (FiligranHQ/xtm-docker#15); the OpenCTI docker repo receives the same treatment via OpenCTI-Platform/docker#578.

### Related issues

*
