### PR TITLE
[docker] Group pgsql-xtm-one with dependencies and document XTM One

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ OpenAEV allows you to customize your stack by selecting specific collectors and 
 - Additional Collectors: Explore a variety of collectors available [here](https://filigran.notion.site/OpenAEV-Ecosystem-30d8eb73d7d04611843e758ddef8941b#fb5f20e515df428994bed1438131cbd1).
 - Additional Injectors: Discover injectors to enhance your simulations [here](https://filigran.notion.site/OpenAEV-Ecosystem-30d8eb73d7d04611843e758ddef8941b#90cfcc2895d441d68b54eda9b57d5d31).
 
+---
+
+## 🤖 XTM One
+
+This stack bundles [XTM One](https://filigran.io), Filigran's AI-powered assistant, alongside OpenAEV. The following services are started by default:
+
+| Service | Description |
+|---------|-------------|
+| `xtm-one` | XTM One platform (web UI + API, exposed on `XTM_ONE_PORT`) |
+| `xtm-one-worker` | XTM One background worker |
+| `pgsql-xtm-one` | Dedicated PostgreSQL + `pgvector` instance for XTM One |
+
+XTM One reuses the shared `redis` and `minio` services and connects to OpenAEV internally via `OPENAEV_API_URL`. OpenAEV registers itself with XTM One using `PLATFORM_REGISTRATION_TOKEN` — this shared secret **must be identical** across every platform connected to the same XTM One instance.
+
+All XTM One configuration (admin credentials, dedicated Postgres credentials, S3 bucket, license, log settings) lives in the `XTM ONE` section of [.env.sample](.env.sample). Once the stack is healthy, XTM One is available on `http://localhost:${XTM_ONE_PORT}` (default `8090`).
+
 ## About
 
 OpenAEV is a product designed and developed by the company [Filigran](https://filigran.io).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,21 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  pgsql-xtm-one:
+    # Dedicated pgvector-enabled instance for XTM One.
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
+      POSTGRES_DB: xtm_one
+    volumes:
+      - pgsqlxtmonedata:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "xtm_one" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   minio:
     image: minio/minio:latest
     volumes:
@@ -284,22 +299,6 @@ services:
   ###########################
   # XTM ONE                 #
   ###########################
-
-  pgsql-xtm-one:
-    # Dedicated pgvector-enabled instance for XTM One.
-    image: pgvector/pgvector:pg17
-    environment:
-      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
-      POSTGRES_DB: xtm_one
-    volumes:
-      - pgsqlxtmonedata:/var/lib/postgresql/data
-    restart: always
-    healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "xtm_one" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   xtm-one:
     image: xtmone/platform:latest


### PR DESCRIPTION
## Summary

Aligns the bundled XTM One configuration with the other XTM docker stacks (`FiligranHQ/xtm-docker`, `OpenCTI-Platform/docker`) for cross-repo consistency.

- Move the dedicated `pgsql-xtm-one` (PostgreSQL + pgvector) service from the `# XTM ONE` block into the `# DEPENDENCIES` section, right after `pgsql`, so it is grouped with the other datastores like in `xtm-docker`. No functional change — `xtm-one` still `depends_on` it.
- Document the bundled XTM One services (`xtm-one`, `xtm-one-worker`, `pgsql-xtm-one`) in the README, which previously did not mention XTM One at all.

## Test plan
- [x] `docker compose --env-file .env.sample -f docker-compose.yml config` validates with no errors
- [ ] Stack boots and XTM One reaches healthy state