### PR TITLE
chore: audit & align issue templates (#143)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/OpenAEV-Platform/docker/security/policy
-    about: Please review our security policy and report vulnerabilities privately and responsibly.
-  - name: Filigran community Slack
-    url: https://community.filigran.io
-    about: Ask questions and chat with the Filigran community.


### PR DESCRIPTION
Closes #143

## Summary
Audit and align the GitHub issue templates under `.github/ISSUE_TEMPLATE/` with the canonical Filigran templates.

- `config.yml` now contains `blank_issues_enabled: true` only
- Removed the duplicate security `contact_link` (native private vulnerability reporting is enabled on this public repo)
- Removed the `Filigran community Slack` `contact_link`
- `bug_report.md`, `feature_request.md`, `question.md` verified consistent with the canonical templates (names, about, titles, labels, types)